### PR TITLE
install 'shared-mime-info' for the 'mimemagic' ruby gem

### DIFF
--- a/huginn/single-process/Dockerfile
+++ b/huginn/single-process/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.6-buster
 
+RUN apt-get update && apt-get install shared-mime-info
+
 COPY docker/scripts/prepare /scripts/
 RUN /scripts/prepare
 


### PR DESCRIPTION
(attempt to fix #3)

I've had a chance to look into the error you are getting, and it seems that the [shared-mime-info](https://packages.debian.org/buster/shared-mime-info) package is expected but missing from the `ruby` base image, needed by the `mimemagic` ruby gem.