### PR TITLE
update huginn patch so it applies cleanly

### DIFF
--- a/huginn/patches/downgrade-mini_racer-and-libv8.patch
+++ b/huginn/patches/downgrade-mini_racer-and-libv8.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 1/1] downgrade mini_racer and libv8
  2 files changed, 6 insertions(+), 10 deletions(-)
 
 diff --git a/Gemfile b/Gemfile
-index cf4f9c94..a840a757 100644
+index c7d286d7..3db30484 100644
 --- a/Gemfile
 +++ b/Gemfile
 @@ -36,7 +36,7 @@ gem 'forecast_io', '~> 2.0.0'     # WeatherAgent
@@ -22,10 +22,10 @@ index cf4f9c94..a840a757 100644
  gem 'mqtt'                        # MQTTAgent
  gem 'slack-notifier', '~> 1.0.0'  # SlackAgent
 diff --git a/Gemfile.lock b/Gemfile.lock
-index 59b86925..bfb71b1d 100644
+index befcc94c..6af6e244 100644
 --- a/Gemfile.lock
 +++ b/Gemfile.lock
-@@ -428,11 +428,7 @@ GEM
+@@ -443,11 +443,7 @@ GEM
        actionmailer (>= 3.2)
        letter_opener (~> 1.0)
        railties (>= 3.2)
@@ -35,21 +35,21 @@ index 59b86925..bfb71b1d 100644
 -    libv8-node (16.10.0.0-x86_64-darwin)
 -    libv8-node (16.10.0.0-x86_64-linux)
 +    libv8 (6.3.292.48.1)
-     liquid (4.0.3)
+     liquid (5.3.0)
      listen (3.0.8)
        rb-fsevent (~> 0.9, >= 0.9.4)
-@@ -459,8 +455,8 @@ GEM
+@@ -474,8 +470,8 @@ GEM
      mini_magick (4.11.0)
      mini_mime (1.1.2)
-     mini_portile2 (2.6.1)
--    mini_racer (0.6.2)
+     mini_portile2 (2.8.0)
+-    mini_racer (0.6.3)
 -      libv8-node (~> 16.10.0.0)
 +    mini_racer (0.2.4)
 +      libv8 (>= 6.3)
-     minitest (5.15.0)
+     minitest (5.16.3)
      mqtt (0.3.1)
      msgpack (1.4.2)
-@@ -799,7 +795,7 @@ DEPENDENCIES
+@@ -816,7 +812,7 @@ DEPENDENCIES
    listen (~> 3.0.5)
    loofah (~> 2.0)
    mini_magick (>= 4.9.4)
@@ -57,13 +57,10 @@ index 59b86925..bfb71b1d 100644
 +  mini_racer (~> 0.2.4)
    mqtt
    multi_xml
-   mysql2 (~> 0.5.2)
-@@ -857,4 +853,4 @@ RUBY VERSION
-    ruby 2.6.5p114
+   mysql2 (~> 0.5)
+@@ -874,4 +870,4 @@ RUBY VERSION
+    ruby 2.7.6p219
  
  BUNDLED WITH
 -   2.3.10
 +   2.3.5
--- 
-2.36.0
-


### PR DESCRIPTION
It seems that the huginn patch doesn't apply cleanly anymore: https://github.com/unixfox/periodic-build-with-github-actions/actions/runs/3743067101/jobs/6354790673

I updated it based on the latest huginn `master` and it should now apply correctly.

However, I do not know the history behind it, so I'm assuming/hoping these versions still work.