### PR TITLE
huginn: fix nokogiri patch, use ubuntu 20.04 and drop support for ARMv7

### DIFF
--- a/.github/workflows/docker-build-huginn.yml
+++ b/.github/workflows/docker-build-huginn.yml
@@ -87,6 +87,6 @@ jobs:
         with:
           context: ./huginn-git
           file: ./huginn/single-process/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: quay.io/unixfox/huginn-single-process:latest, quay.io/unixfox/huginn-single-process:build-${{ env.timestamp }}

--- a/huginn/patches/force_nokogiri_compilation.patch
+++ b/huginn/patches/force_nokogiri_compilation.patch
@@ -4,9 +4,9 @@ Date: Tue, 10 May 2022 19:42:10 +0200
 Subject: [PATCH 1/1] force nokogiri compilation
 
 ---
- Gemfile      |  2 +-
- Gemfile.lock | 14 +++++---------
- 2 files changed, 6 insertions(+), 10 deletions(-)
+ Gemfile      | 2 +-
+ Gemfile.lock | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Gemfile b/Gemfile
 index c7d286d7..c524e46a 100644
@@ -31,3 +31,5 @@ index befcc94c..214fc10f 100644
  BUNDLED WITH
 -   2.3.10
 +   2.3.26
+--
+2.39.0

--- a/huginn/scripts/prepare
+++ b/huginn/scripts/prepare
@@ -23,7 +23,6 @@ minimal_apt_get_install='apt-get install -y --no-install-recommends'
 apt-get update
 apt-get dist-upgrade -y --no-install-recommends
 $minimal_apt_get_install software-properties-common
-add-apt-repository -y ppa:brightbox/ruby-ng-experimental
 apt-get update
 $minimal_apt_get_install build-essential checkinstall git-core \
   zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev \

--- a/huginn/single-process/Dockerfile
+++ b/huginn/single-process/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY docker/scripts/prepare /scripts/
 RUN /scripts/prepare


### PR DESCRIPTION
(Continuation of effort on https://github.com/unixfox/periodic-build-with-github-actions/issues/3)

After [a lot](https://github.com/emilburzo/periodic-build-with-github-actions/actions/) of experimentation, a new PR with the following changes

### Fix nokogiri patch

It just wasn't properly formatted.

### Switch to Ubuntu 20.04

Contradictory to what I previously said, it looks like ubuntu 20.04 is a better choice because it has ruby2.7 for all architectures and we can drop the `ruby-ng-experimental` PPA (which only has `amd64`, but no `arm64`)

### Drop support for ARMv7 (32bit)

Unfortunately, [it seems](https://github.com/emilburzo/periodic-build-with-github-actions/actions/runs/3759106133/jobs/6388256591) that SSL is not working in ARMv7:

```
#15 633.8 ERROR:  SSL verification error at depth 1: unable to get local issuer certificate (20)
#15 633.8 ERROR:  You must add /OU=GlobalSign Root CA - R3/O=GlobalSign/CN=GlobalSign to your local trusted store
#15 633.8 ERROR:  While executing gem ... (Gem::RemoteFetcher::FetchError)
#15 633.8     SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate) (https://rubygems.org/specs.4.8.gz)
```

And I wasn't really able to find out why, as everything should be identical to `amd64` and `arm64`

Even the [rubygems debug script](https://github.com/emilburzo/periodic-build-with-github-actions/actions/runs/3759305908/jobs/6388711277) wasn't of much use.

I hope there's not too many users still relying on 32bit ARM, but I don't see any other option than dropping it.